### PR TITLE
Render teams

### DIFF
--- a/src/components/Team.js
+++ b/src/components/Team.js
@@ -5,7 +5,7 @@ import { getTeam } from '../api';
 export default class Team extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
-    chidren: PropTypes.func.isRequired,
+    children: PropTypes.func.isRequired,
   };
 
   state = {
@@ -17,19 +17,13 @@ export default class Team extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    nextProps !== this.props && this.fetchTeam(this.props.id);
+    nextProps.id !== this.props.id && this.fetchTeam(nextProps.id);
   }
 
   fetchTeam = (id) => {
-    this.setState({
-      team: null,
-    });
+    this.setState(() => ({ team: null }));
 
-    getTeam().then((team) =>
-      this.setState({
-        team,
-      })
-    );
+    getTeam(id).then((team) => this.setState(() => ({ team })));
   };
 
   render() {

--- a/src/components/Team.js
+++ b/src/components/Team.js
@@ -1,0 +1,38 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { getTeam } from '../api';
+
+export default class Team extends Component {
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    chidren: PropTypes.func.isRequired,
+  };
+
+  state = {
+    team: null,
+  };
+
+  componentDidMount() {
+    this.fetchTeam(this.props.id);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    nextProps !== this.props && this.fetchTeam(this.props.id);
+  }
+
+  fetchTeam = (id) => {
+    this.setState({
+      team: null,
+    });
+
+    getTeam().then((team) =>
+      this.setState({
+        team,
+      })
+    );
+  };
+
+  render() {
+    return this.props.children(this.state.team);
+  }
+}

--- a/src/components/Teams.js
+++ b/src/components/Teams.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import Sidebar from './Sidebar';
-import { getTeamNames, getTeam } from '../api';
-import { Route } from 'react-router-dom';
+import { getTeamNames } from '../api';
+import { Route, Link } from 'react-router-dom';
+import TeamLogo from './TeamLogo';
+import Team from './Team';
 
 export default class Teams extends Component {
   state = {
@@ -32,9 +34,39 @@ export default class Teams extends Component {
 
         <Route
           path={`${match.url}/:teamId`}
-          render={({ match }) => {
-            return <div className='panel'>Team</div>;
-          }}
+          render={({ match }) => (
+            <div className='panel'>
+              <Team id={match.params.teamId}>
+                {(team) =>
+                  !team ? (
+                    <h1>Loading...</h1>
+                  ) : (
+                    <div style={{ width: '100%' }}>
+                      <TeamLogo id={match.params.teamId} className='center' />
+                      <h1 className='medium-header'>{team.name}</h1>
+                      <ul className='info-list row'>
+                        <li className='header'>
+                          Established
+                          <div>{team.established}</div>
+                        </li>
+                        <li className='header'>
+                          Manager
+                          <div>{team.manager}</div>
+                        </li>
+                        <li className='header'>
+                          Coach
+                          <div>{team.coach}</div>
+                        </li>
+                      </ul>
+                      <Link className='center btn-main' to={`/${team.id}`}>
+                        {team.name} Team Page
+                      </Link>
+                    </div>
+                  )
+                }
+              </Team>
+            </div>
+          )}
         />
       </div>
     );

--- a/src/components/Teams.js
+++ b/src/components/Teams.js
@@ -2,12 +2,12 @@ import React, { Component } from 'react';
 import Sidebar from './Sidebar';
 import { getTeamNames, getTeam } from '../api';
 import { Route } from 'react-router-dom';
-import { parse } from 'query-string';
 
 export default class Teams extends Component {
   state = {
     teams: [],
     loading: true,
+    selectedTeam: {},
   };
 
   componentDidMount() {
@@ -29,6 +29,13 @@ export default class Teams extends Component {
         {!loading && location.pathname === '/teams' && (
           <div className='sidebar-instruction'>Select a team</div>
         )}
+
+        <Route
+          path={`${match.url}/:teamId`}
+          render={({ match }) => {
+            return <div className='panel'>Team</div>;
+          }}
+        />
       </div>
     );
   }


### PR DESCRIPTION
- Setup preliminary nested route component for <Teams /> when a team is selected from the list.
- Created preliminary <Team /> that fetches team data and passes it down to its children.
- Fixed bug inside componetWillReceiveProps method that was calling this.props.id instead of nextProps.id.
- Invoked this.props.children in <Team /> and set up the appropriate UI to be rendered, including a Link that routes to the selected team's full Team Page.