### PR TITLE
Team page setup

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,6 +4,7 @@ import Nav from './Nav';
 import Home from './Home';
 import Players from './Players';
 import Teams from './Teams';
+import TeamPage from './TeamPage';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
         <Route exact path={'/'} component={Home} />
         <Route path={'/players'} component={Players} />
         <Route path={'/teams'} component={Teams} />
+        <Route path={'/:teamId'} component={TeamPage} />
         <Route
           render={() => (
             <h1 className='text-center'>{'Uh-Oh... Four Oh Four'}</h1>

--- a/src/components/Players.js
+++ b/src/components/Players.js
@@ -30,7 +30,6 @@ export default class Players extends Component {
   render() {
     const { players, loading } = this.state;
     const { match, location } = this.props;
-    console.log(players);
     return (
       <div className='container two-column'>
         <Sidebar

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -28,26 +28,24 @@ Sidebar.porpTypes = {
 };
 
 export default function Sidebar({ title, list, loading, match, location }) {
-  return (
+  return loading ? (
+    <h1 className='center'>LOADING...</h1>
+  ) : (
     <div>
       <h3 className='header'>{title}</h3>
-      {loading ? (
-        <h4>LOADING...</h4>
-      ) : (
-        <ul className='sidebar-list'>
-          {list.map((item) => (
-            <CustomLink
-              key={item}
-              to={{
-                pathname: `${match.url}/${slug(item)}`,
-                search: location.search,
-              }}
-            >
-              {item.toUpperCase()}
-            </CustomLink>
-          ))}
-        </ul>
-      )}
+      <ul className='sidebar-list'>
+        {list.map((item) => (
+          <CustomLink
+            key={item}
+            to={{
+              pathname: `${match.url}/${slug(item)}`,
+              search: location.search,
+            }}
+          >
+            {item.toUpperCase()}
+          </CustomLink>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/components/TeamPage.js
+++ b/src/components/TeamPage.js
@@ -1,0 +1,98 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Route, Link, Redirect } from 'react-router-dom';
+import { getTeamsArticles, getTeamNames } from '../api';
+import slug from 'slug';
+import Team from './Team';
+import TeamLogo from './TeamLogo';
+
+export default class TeamPage extends Component {
+  state = {
+    loading: true,
+    articles: [],
+    teamNames: [],
+  };
+
+  componentDidMount() {
+    const { match } = this.props;
+    Promise.all([getTeamsArticles(match.params.teamId), getTeamNames()]).then(
+      ([articles, teamNames]) =>
+        this.setState(() => ({
+          loading: false,
+          articles,
+          teamNames,
+        }))
+    );
+  }
+
+  render() {
+    const { match, location } = this.props;
+    const { articles, teamNames, loading } = this.state;
+    const { teamId } = match.params;
+
+    if (!loading && !teamNames.includes(teamId)) return <Redirect to='/' />;
+
+    return (
+      <Team id={teamId}>
+        {(team) =>
+          !team ? (
+            <h1>Loading...</h1>
+          ) : (
+            <div className='panel'>
+              <TeamLogo id={team.id} />
+              <h1 className='medium-header'>{team.name}</h1>
+              <h4 style={{ margin: 5 }}>
+                <Link
+                  className='roster'
+                  cursor='pointer'
+                  to={{
+                    pathname: '/players',
+                    search: `?/teamId=${teamId}`,
+                  }}
+                >
+                  View Roster
+                </Link>
+              </h4>
+              <h4>Championships</h4>
+              <ul className='championships'>
+                {team.championships.map((chip) => (
+                  <li key={chip}>{chip}</li>
+                ))}
+              </ul>
+              <ul className='info-list row' style={{ width: '100%' }}>
+                <li>
+                  Established<div>{team.established}</div>
+                </li>
+                <li>
+                  Manager<div>{team.manager}</div>
+                </li>
+                <li>
+                  Coach<div>{team.coach}</div>
+                </li>
+                <li>
+                  Record
+                  <div>
+                    {team.wins}-{team.losses}
+                  </div>
+                </li>
+              </ul>
+              <h2 className='header'>Articles</h2>
+              <ul className='articles'>
+                {articles.map((article, id) => (
+                  <li key={article.id} cursor='pointer'>
+                    <Link to={`${match.url}/articles/${article.id}`}>
+                      <h4 className='article-title'>{article.title}</h4>
+                      <div className='article-date'>
+                        {article.date.toLocaleDateString()}
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )
+        }
+      </Team>
+    );
+  }
+}

--- a/src/components/TeamPage.js
+++ b/src/components/TeamPage.js
@@ -47,7 +47,7 @@ export default class TeamPage extends Component {
                   cursor='pointer'
                   to={{
                     pathname: '/players',
-                    search: `?/teamId=${teamId}`,
+                    search: `?teamId=${teamId}`,
                   }}
                 >
                   View Roster

--- a/src/components/TeamPage.js
+++ b/src/components/TeamPage.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { Route, Link, Redirect } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { getTeamsArticles, getTeamNames } from '../api';
-import slug from 'slug';
 import Team from './Team';
 import TeamLogo from './TeamLogo';
 
@@ -26,7 +24,7 @@ export default class TeamPage extends Component {
   }
 
   render() {
-    const { match, location } = this.props;
+    const { match } = this.props;
     const { articles, teamNames, loading } = this.state;
     const { teamId } = match.params;
 


### PR DESCRIPTION
- Created TeamPage.js and TeamPage component.
- Added ambiguous team route to App.js to render TeamPage component.
- Added TeamPage component functionality which is rendered by invoking Team component's this.props.children and displays pertinent team info as well as related team articles.
- Changed how Sidebar component rendered loading in component.
- Removed forgotten console.log from Players component.
- Fixed bug in link to team roster that was causing all players to render instead of team players only.
- Removed unnecessary imports and props.
